### PR TITLE
Fix add account to transaction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 config.py 
 __pycache__
 venv
+.vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python.pythonPath": "c:\\Users\\Helena I Guimarães\\git\\my_finances\\venv\\Scripts\\python.exe"
-}

--- a/app.py
+++ b/app.py
@@ -57,7 +57,7 @@ def new_transaction():
     cursor.execute(select_accounts,account_data)
     all_accounts = cursor.fetchall()
     cnx.close()
-    return render_template("transactions/edit.html", categories=all_categories, date= datetime.now(), accounts=all_accounts)
+    return render_template("transactions/edit.html", categories=all_categories, date= datetime.now(), destination_accnt_id=None, accounts=all_accounts)
 
 @app.route('/transactions/<id>')
 @login_required

--- a/script_my_finances.sql
+++ b/script_my_finances.sql
@@ -1,4 +1,4 @@
-create table transactions (id int not null auto_increment, description varchar(150), user_id int not null,category_id int, date date, value decimal(12,2) not null, primary key(id));
+create table transactions (id int not null auto_increment, description varchar(150), user_id int not null,category_id int, date date, value decimal(12,2) not null, destination_accnt_id int, source_accnt_id int not null, primary key(id));
 create table users (name varchar(100), email varchar(100), password varchar(150), id int auto_increment not null, primary key(id));
 create table categories (id int not null auto_increment, category varchar(100) not null, user_id int not null, primary key(id));
 create table accounts (id int not null auto_increment, name varchar(150), user_id int not null, type varchar(100), primary key(id));

--- a/templates/transactions/edit.html
+++ b/templates/transactions/edit.html
@@ -39,7 +39,7 @@
     <input type="submit" class="ui teal submit button"  placeholder="Submit"/>
 </form>
 <script>
-{% if destination_accnt_id == "" %}
+{% if destination_accnt_id is none or destination_accnt_id == "" %}
 let destinationAccntID = -1;
 {% else %}
 let destinationAccntID = {{destination_accnt_id}};


### PR DESCRIPTION
### What's in this PR?

- Add `destination_accnt_id` and `source_accnt_id` to the SQL script
- Fix some issues with the create/edit transaction page, on the destination account combo

### How did I test this?

- Manually, locally