### PR TITLE
transactions per category and  per account

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -261,7 +261,24 @@ def save_categories():
 @app.route('/dashboard')
 @login_required
 def dashboard():
-    return render_template("home_page/index.html")
+    cnx = mysql.connector.connect(user=MYSQL_USER, password=MYSQL_PASSWORD,
+                                host=MYSQL_HOST,
+                                database=MYSQL_DATABASE)
+    cursor = cnx.cursor()
+    count = ("select count(t.id),c.category from transactions t join categories c where t.category_id=c.id and t.user_id =%s group by t.category_id  order by c.category asc")
+    select_count= (session["id"],)
+    cursor.execute(count,select_count)
+    counts = []
+    for row in cursor:
+        counts.append({"count": row[0], "category": row[1]})
+    count_a = ("select count(t.id),a.name from transactions t join accounts a where t.source_accnt_id=a.id and t.user_id =%s group by t.source_accnt_id order by name asc")
+    select_count_a= (session["id"],)
+    cursor.execute(count_a,select_count_a)
+    all_accounts = []
+    for row in cursor:
+        all_accounts.append({"count": row[0], "account": row[1]})
+    cnx.close() 
+    return render_template("home_page/index.html", count_categories=counts, count_accounts=all_accounts)
 
 @app.route('/accounts')
 @login_required

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -265,20 +265,24 @@ def dashboard():
                                 host=MYSQL_HOST,
                                 database=MYSQL_DATABASE)
     cursor = cnx.cursor()
-    count = ("select count(t.id),c.category from transactions t join categories c where t.category_id=c.id and t.user_id =%s group by t.category_id  order by c.category asc")
-    select_count= (session["id"],)
-    cursor.execute(count,select_count)
-    counts = []
+    count_c = ("select count(t.id),c.category from transactions t join categories c where t.date between %s and %s and t.category_id=c.id and t.user_id =%s group by t.category_id  order by c.category asc")
+    end_date_c = date.today()
+    start_date_c= date.fromordinal(end_date_c.toordinal()-30) 
+    select_count_c= (start_date_c,end_date_c,session["id"])
+    cursor.execute(count_c,select_count_c)
+    all_categories = []
     for row in cursor:
-        counts.append({"count": row[0], "category": row[1]})
-    count_a = ("select count(t.id),a.name from transactions t join accounts a where t.source_accnt_id=a.id and t.user_id =%s group by t.source_accnt_id order by name asc")
-    select_count_a= (session["id"],)
+        all_categories.append({"count": row[0], "category": row[1]})
+    count_a = ("select count(t.id),a.name from transactions t join accounts a where t.date between %s and %s and t.source_accnt_id=a.id and t.user_id =%s group by t.source_accnt_id order by name asc")
+    end_date_a = date.today()
+    start_date_a= date.fromordinal(end_date_c.toordinal()-30)
+    select_count_a= (start_date_a,end_date_a,session["id"])
     cursor.execute(count_a,select_count_a)
     all_accounts = []
     for row in cursor:
         all_accounts.append({"count": row[0], "account": row[1]})
     cnx.close() 
-    return render_template("home_page/index.html", count_categories=counts, count_accounts=all_accounts)
+    return render_template("home_page/index.html", count_categories=all_categories, count_accounts=all_accounts)
 
 @app.route('/accounts')
 @login_required

--- a/app/templates/home_page/index.html
+++ b/app/templates/home_page/index.html
@@ -3,4 +3,32 @@
 <h1>
     Welcome {{session['name']}}!
 </h1>
+<div class="ui teal floated segment">
+    <div class="ui two column very relaxed grid">
+      <div class="column">
+        <h2 class="ui left floated header">Categories</h2>
+        <div class="ui clearing divider"></div>
+        <p>
+          {% for category in count_categories %}       
+            <h4>{{category.category}}</h4>     
+            <p> {{category.count}} transactions in this category.</p>
+            <div class="ui clearing divider"></div>
+          {% endfor %}
+        </p>
+      </div>
+      <div class="column">
+        <h2 class="ui left floated header">Accounts</h2>
+        <div class="ui clearing divider"></div>
+        <p>
+          {% for account in count_accounts %}
+            <h4>{{account.account}}</h4>
+            <p>{{account.count}} transactions in this account.</p>
+            <div class="ui clearing divider"></div>
+          {% endfor %}
+        </p>
+      </div>
+    </div>
+    <div class="ui vertical divider">
+    </div>
+</div>
 {% endblock %}

--- a/app/templates/home_page/index.html
+++ b/app/templates/home_page/index.html
@@ -11,7 +11,7 @@
         <p>
           {% for category in count_categories %}       
             <h4>{{category.category}}</h4>     
-            <p> {{category.count}} transactions in this category.</p>
+            <p> {{category.count}} transactions in this category on the last 30 days.</p>
             <div class="ui clearing divider"></div>
           {% endfor %}
         </p>
@@ -22,7 +22,7 @@
         <p>
           {% for account in count_accounts %}
             <h4>{{account.account}}</h4>
-            <p>{{account.count}} transactions in this account.</p>
+            <p>{{account.count}} transactions in this account on the last 30 days.</p>
             <div class="ui clearing divider"></div>
           {% endfor %}
         </p>

--- a/app/templates/profile/index.html
+++ b/app/templates/profile/index.html
@@ -1,15 +1,17 @@
 {% extends "base/layout.html" %}
 {% block content %}
 <h1>Hello {{session['name']}}, welcome to your profile page.</h1>
-<h2>Your preferences:</h2>
-{% if preference == "en-us" %}
-<h3>Date: month/day/year</h3>
-<h3>Numbers: 0.00 </h3>
-<h3>Currency: $ (us dollar)</h3>
-{% elif preference == "pt-br" %}
-<h3>Date: day/month/year</h3>
-<h3>Numbers: 0,00 </h3>
-<h3>Currency: R$ (reais)</h3>
-{% endif %}
-<a href="/profile/prefences">Edit prefences</a>
+<div class="ui teal floated segment"> 
+    <h2>Your preferences:</h2>
+    {% if preference == "en-us" %}
+    <h3>Date: month/day/year</h3>
+    <h3>Numbers: 0.00 </h3>
+    <h3>Currency: $ (us dollar)</h3>
+    {% elif preference == "pt-br" %}
+    <h3>Date: day/month/year</h3>
+    <h3>Numbers: 0,00 </h3>
+    <h3>Currency: R$ (reais)</h3>
+    {% endif %}
+    <a href="/profile/prefences">Edit prefences</a>
+</div>
 {% endblock %}


### PR DESCRIPTION
**What changed?**
- user can now see how many transactions each _category_ has on a 30 day period on the dashboard;
- user can now see how many transactions each _account_ has on a 30 day period on the dashboard;
- dashboard has a display of usefull information such as:

> how many categories the user has attached to a transaction
how many accounts the user has attached to a transaction

**How did I test it?**
Locally. 